### PR TITLE
'test/unit' is not available in ruby 2.2

### DIFF
--- a/test/scenarios/require_test_unit.rb
+++ b/test/scenarios/require_test_unit.rb
@@ -1,5 +1,9 @@
 # Imagine this is your rails app
-require 'test/unit'
+if RUBY_VERSION =~ /^2\.2/
+
+else
+  require 'test/unit'
+end
 
 # Now cucumber loads
 require "multi_test"

--- a/test/scenarios/require_test_unit.rb
+++ b/test/scenarios/require_test_unit.rb
@@ -1,8 +1,10 @@
 # Imagine this is your rails app
-if RUBY_VERSION =~ /^2\.2/
 
-else
+# Some ruby versions do not include 'test/unit' stdlib.
+begin
   require 'test/unit'
+rescue LoadError => _
+
 end
 
 # Now cucumber loads


### PR DESCRIPTION
#### Motivation

Fixes tests for ruby 2.2.0.

See **gem is not compatible with ruby 2.2** [#6](https://github.com/cucumber/multi_test/issues/6) for details.

I am not very happy with this - I don't think it meshes well with your existing testing framework.  I will not be put-off if this is rejected.