### PR TITLE
If no best assertion library exists, don't try to extend the World

### DIFF
--- a/lib/multi_test.rb
+++ b/lib/multi_test.rb
@@ -28,6 +28,9 @@ module MultiTest
   end
 
   def self.extend_with_best_assertion_library(object)
-    AssertionLibrary.detect_best.extend_world(object)
+   best_library = AssertionLibrary.detect_best
+    if best_library
+      best_library.extend_world(object)
+    end
   end
 end

--- a/test/scenarios/bundler_require.rb
+++ b/test/scenarios/bundler_require.rb
@@ -4,4 +4,4 @@ Bundler.require
 # Now cucumber loads
 require "multi_test"
 MultiTest.disable_autorun
-
+MultiTest.extend_with_best_assertion_library(self)

--- a/test/scenarios/require_test_unit.rb
+++ b/test/scenarios/require_test_unit.rb
@@ -4,3 +4,4 @@ require 'test/unit'
 # Now cucumber loads
 require "multi_test"
 MultiTest.disable_autorun
+MultiTest.extend_with_best_assertion_library(self)


### PR DESCRIPTION
#### Motivation

A fix for **ruby 2.2.0 + cucumber 1.3.18 raises undefined method `extend_world' for nil:NilClass**[#798](https://github.com/cucumber/cucumber/issues/798).

I am not sure what the consequences of have no AssertionLibrary available.

#### Notes

Will fail on Travis CI on ruby 2.2.0 until **'test/unit' is not available in ruby 2.2** #7 or something like it is merged.

See also: **gem is not compatible with ruby 2.2** #6


