### PR TITLE
CHANGELOG updates for monorepo's #251

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
+
+## Unreleased
+
+### Changed
+
+* As per [#251](https://github.com/cucumber/cucumber/issues/251): renamed History.md to CHANGELOG.md, added contributing message at beginning, and other formatting.
+
+
 ## [v0.1.2](https://github.com/cucumber/multi_test/compare/v0.1.1...v0.1.2)
 
 * Ensure that detecting assetion library doesn't fail if no test framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ### Changed
 
-* As per [#251](https://github.com/cucumber/cucumber/issues/251): renamed History.md to CHANGELOG.md, added contributing message at beginning, and other formatting.
+* As per [#251](https://github.com/cucumber/cucumber/issues/251): renamed History.md to CHANGELOG.md, added contributing message at beginning, and other formatting. ([#12](https://github.com/cucumber/multi_test/pull/12) [jaysonesmith](https://github.com/jaysonesmith/))
 
 
 ## [v0.1.2](https://github.com/cucumber/multi_test/compare/v0.1.1...v0.1.2)


### PR DESCRIPTION
## Summary

CHANGELOG.md updates as per [cucumber/cucumber #251](https://github.com/cucumber/cucumber/issues/251)

## Details

* Renamed History.md to CHANGELOG.md
* Added category name
* Added contributing message at top

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Documentation update