### PR TITLE
CI: Update to latest Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,13 @@
 before_install:
-  gem install bundler -v 1.5.1
+  gem install bundler
 rvm:
-  - 2.3.1
-  - 2.4.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
   - ruby-head
 script: make
 matrix:
   include:
-    - rvm: 1.9.3
-      env: EXCLUDED_DIRS="activesupport-5.0.0"
-    - rvm: 2.0.0
-      env: EXCLUDED_DIRS="activesupport-5.0.0"
-    - rvm: 2.1.3
-      env: EXCLUDED_DIRS="activesupport-5.0.0"
-    - rvm: 2.2.0
-      env: EXCLUDED_DIRS="activesupport-5.0.0"
     - rvm: jruby
       env: EXCLUDED_DIRS="activesupport-5.0.0"
   allow_failures:


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rbenv/ruby-build/tree/master/share/ruby-build