### PR TITLE
CI: use jruby-9.2.6.0 (latest)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
 script: make
 matrix:
   include:
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
       env: EXCLUDED_DIRS="activesupport-5.0.0"
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)