### PR TITLE
Fix requirements in gemspec

### DIFF
--- a/multi_test.gemspec
+++ b/multi_test.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
 
   s.platform    = Gem::Platform::RUBY
 
-  s.rubygems_version = ">= 1.6.1"
+  s.required_ruby_version = ">= 2.0"
+  s.required_rubygems_version = ">= 1.6.1"
   s.files            = `git ls-files`.split("\n").
     reject { |path| path =~ /\.gitignore$/ }.
     reject { |path| path =~ /^test\// }


### PR DESCRIPTION
Set requirements in gemspec for:
- ruby >= 2.0
- rubygem: use the right property `required_rubygems_version` rather than `rubygems_version`